### PR TITLE
Some small improvements

### DIFF
--- a/AddU2hosts.sh
+++ b/AddU2hosts.sh
@@ -30,11 +30,9 @@ default_host() {
 # CloudflareST 测试程序
 cloudflare_st() {
   echo -e "${Green_font_prefix}> 正在下载 CloudflareST 测试程序${Font_color_suffix}";
-  wget -P /home/CloudflareSTtar ${web_proxy}https://cf.kevinmx.workers.dev/?url=https%3A%2F%2Fgithub.com%2FXIU2%2FCloudflareSpeedTest%2Freleases%2Fdownload%2Fv2.0.3%2FCloudflareST_linux_amd64.tar.gz -O CloudflareST_linux_amd64.tar.gz
-  tar -zxf /home/CloudflareSTtar/CloudflareST_linux_amd64.tar.gz -C /home/CloudflareSTtar
-  mv /home/CloudflareSTtar/CloudflareST /${USER}
-  mv /home/CloudflareSTtar/ip.txt /${USER}
-  chmod +x /${USER}/CloudflareST
+  wget ${web_proxy}https://cf.kevinmx.workers.dev/?url=https%3A%2F%2Fgithub.com%2FXIU2%2FCloudflareSpeedTest%2Freleases%2Fdownload%2Fv2.0.3%2FCloudflareST_linux_amd64.tar.gz -O CloudflareST_linux_amd64.tar.gz
+  tar -zxf CloudflareST_linux_amd64.tar.gz
+  chmod +x CloudflareST
   echo "104.25.26.31" > nowip.txt
 	echo -e "${Green_font_prefix}> 开始测速...${Font_color_suffix}";
 	NOWIP=$(head -1 nowip.txt)
@@ -52,10 +50,7 @@ cloudflare_st() {
 	sed -i 's/'${NOWIP}'/'${BESTIP}'/g' /etc/hosts
 	echo -e "${Green_font_prefix}> 完成...${Font_color_suffix}";
   echo -e "${Green_font_prefix}> 清理 CloudflareST 测试程序${Font_color_suffix}";
-  rm -rf /home/CloudflareSTtar*
-  rm -rf /${USER}/CloudflareST
-  rm -rf /${USER}/nowip.txt
-  rm -rf /${USER}/ip.txt
+  rm -rf *.txt cfst_hosts.sh result.csv CloudflareST*
 }
 
 

--- a/AddU2hosts.sh
+++ b/AddU2hosts.sh
@@ -38,7 +38,9 @@ cloudflare_st() {
   echo "104.25.26.31" > nowip.txt
 	echo -e "${Green_font_prefix}> 开始测速...${Font_color_suffix}";
 	NOWIP=$(head -1 nowip.txt)
-    ./CloudflareST
+    # 可在 -url 后替换为你自建的或他人提供的其他测速点，避免Cloudflare限速
+    # 自建方法详情请见 https://github.com/XIU2/CloudflareSpeedTest/issues/168
+    ./CloudflareST -url https://cfst.kevinmx.workers.dev/200mb.test
 	BESTIP=$(sed -n "2,1p" result.csv | awk -F, '{print $1}')
 	echo ${BESTIP} > nowip.txt
 	echo -e "\n旧 IP 为 ${NOWIP}\n${Yellow_font_prefix}新 IP 为 ${BESTIP}${Font_color_suffix}\n"

--- a/AddU2hosts.sh
+++ b/AddU2hosts.sh
@@ -30,7 +30,7 @@ default_host() {
 # CloudflareST 测试程序
 cloudflare_st() {
   echo -e "${Green_font_prefix}> 正在下载 CloudflareST 测试程序${Font_color_suffix}";
-  wget -P /home/CloudflareSTtar ${web_proxy}https://github.com/XIU2/CloudflareSpeedTest/releases/download/v1.4.10/CloudflareST_linux_amd64.tar.gz
+  wget -P /home/CloudflareSTtar ${web_proxy}https://cf.kevinmx.workers.dev/?url=https%3A%2F%2Fgithub.com%2FXIU2%2FCloudflareSpeedTest%2Freleases%2Fdownload%2Fv2.0.3%2FCloudflareST_linux_amd64.tar.gz -O CloudflareST_linux_amd64.tar.gz
   tar -zxf /home/CloudflareSTtar/CloudflareST_linux_amd64.tar.gz -C /home/CloudflareSTtar
   mv /home/CloudflareSTtar/CloudflareST /${USER}
   mv /home/CloudflareSTtar/ip.txt /${USER}

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@
  1. 一键运行脚本 
 
  ```shell
-bash <(curl -sSL https://startworld.online/https://raw.githubusercontent.com/UCoinTeams/AddU2hosts/main/AddU2hosts.sh)
+curl -sSL https://startworld.online/https://raw.githubusercontent.com/UCoinTeams/AddU2hosts/main/AddU2hosts.sh | sudo bash
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AddU2hosts
 使用CloudflareSpeedTest 自动添加替换更新 U2 Hosts
 
+`PS: 使用前请关闭本地网络/路由器上的各类代理/网络加速服务，或将其切换至GFWList模式而非绕过大陆IP模式，以确保测试结果准确。`
+
 ## Windows 使用方法
 
  1. 下载本程序 


### PR DESCRIPTION
TLDR: 针对Linux用户的小修小补。

CloudflareST: 使用自建Cloudflare Workers反代下载，版本更新至2.0.3，下载测速URL改为我的自建Cloudflare Workers节点（避免限速）。

Linux脚本：修复clone整个仓库/在子文件夹中无法正常执行的问题。

README：Linux一键方式改用`sudo`执行。增加了一条小tip。